### PR TITLE
Update entrypoint parsing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ set_tag() {
   if [ -n "${INPUT_CREATED_TAG}" ]; then
     TAG=${INPUT_CREATED_TAG}
   else
-    TAG="$(echo ${GITHUB_REF} | grep tags | grep -o "[^/]*$" || true)"
+    TAG="$(echo ${GITHUB_REF} | grep tags | sed --regexp-extended 's/^\w+\/\w+\///g' || true)"
   fi
 }
 


### PR DESCRIPTION
Changing the grep to a sed to account for tags named like '1.2.3-feature/myfeaturehere' which were being parsed to only 'myfeaturehere' and therefore not matching the version regex we had provided.