### PR TITLE
Update curl to the latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16 as base
 
-RUN apk add --no-cache jq=1.6-r1 curl=7.83.1-r3
+RUN apk add --no-cache jq=1.6-r1 curl=7.83.1-r4
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN curl -s https://api.github.com/repos/dahlia/submark/releases/tags/0.3.1 |  jq -r '.assets[] | select(.browser_download_url | contains("linux-x86_64"))  | .browser_download_url' | xargs curl -o /usr/local/bin/submark -sSL &&  chmod +x /usr/local/bin/submark


### PR DESCRIPTION
Bump: <https://git.alpinelinux.org/aports/commit/main/curl/APKBUILD?h=3.16-stable&id=480a2dc4f712308d90f8b4e101941b73d9a0d61e>

Fixes the following error:

```
Step 1/6 : FROM alpine:3.16 as base
 ---> 9c6f07244728
Step 2/6 : RUN apk add --no-cache jq=1.6-r1 curl=7.83.1-r3
 ---> Running in 12e13ff80b41
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  curl-7.83.1-r4:
    breaks: world[curl=7.83.1-r3]
The command '/bin/sh -c apk add --no-cache jq=1.6-r1 curl=7.83.1-r3' returned a non-zero code: 1
```